### PR TITLE
Only look for `opkg` if needed to install `perl`

### DIFF
--- a/signature-patch.sh
+++ b/signature-patch.sh
@@ -1,14 +1,13 @@
 #!/opt/bin/sh
 set -e
 
-if ! command -v opkg &>/dev/null; then
-    echo "opkg could not be found"
-    echo "Please install it first. https://github.com/toltec-dev/toltec"
-    exit 1
-fi
-
 if ! command -v perl &>/dev/null; then
     echo "perl could not be found"
+    if ! command -v opkg &>/dev/null; then
+        echo "opkg could not be found"
+        echo "Please install it first. https://github.com/toltec-dev/toltec"
+        exit 1
+    fi
     echo "Downloading and installing perl"
     opkg install perl
 fi


### PR DESCRIPTION
If `perl` is already installed using some other method, there's no need to require that `opkg` also be installed.